### PR TITLE
Add default 3D rules for arbitrary pages

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,20 +1,23 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-window.console.log = function () { ipcRenderer.invoke("console", ...arguments); console.log(...arguments);};
-window.console.error = function () { ipcRenderer.invoke("console", ...arguments); console.error(...arguments);};
-
-
 contextBridge.exposeInMainWorld('ipcRenderer', {
   onViewportGeometry: (cb) => ipcRenderer.on('viewportGeometry', cb),
   onPaint: (cb) => ipcRenderer.on('paint', cb),
-  onReset: (cb) => ipcRenderer.on('reset', cb),
+  onPaint3D: (cb) => ipcRenderer.on('paint3d', cb),
+  onReset3D: (cb) => ipcRenderer.on('reset3d', cb),
   scroll: (delta) => ipcRenderer.invoke('scroll', delta),
   setMode: (mode) => ipcRenderer.invoke('setMode', mode),
   sendClick: (x, y) => ipcRenderer.invoke('sendClick', x, y),
   isLoaded: () => ipcRenderer.invoke('browserIsLoaded'),
+  toggleFeatureInContent: (name) => ipcRenderer.invoke('toggleFeatureInContent', name),
   toggle3d: _ => ipcRenderer.invoke('toggle3d'),
   toggleIllustrate: _ => ipcRenderer.invoke('toggle-illustrate'),
   toggleNavigate: _ => ipcRenderer.invoke('toggle-navigate')
+});
+
+contextBridge.exposeInMainWorld('logger', {
+  log: function () { ipcRenderer.invoke("console", ...arguments); console.log(...arguments); },
+  error: function () { ipcRenderer.invoke("console", ...arguments); console.error(...arguments); }
 });
 
 


### PR DESCRIPTION
Various improvements to 3D mode:
- 3D mode can be enabled on any page, it applies a very basic set of rules by default. To my surprise, that works well with Wikipedia pages, even though there are some artefacts. Also, scrolling is *not* supported (not to mention interactions with created 3D planes).
- 3D toggle animates the planes in and out for smoother transitions. That's not perfect but, hey, that's a proof of concept!
- Enabling 3D no longer requires a 'paint' event. The code currently keeps an eye on the last painted image so that it may extract the feature rectangles when needed. That's probably not a good idea but, hey, did I mention it's a proof of concept?

Update includes some message renames to make things hopefully more readable. 3D painting is now completely separated from the regular 'paint' event for instance.

Also, preload.js now also exports a `logger` instance to the immersive browser so as not to have to open a dev tools when debugging problems.